### PR TITLE
Add MQTT Section Control client

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ In order to contribute to AgOpenGPS, follow these steps:
 - [PCB and Firmware Repository](https://github.com/agopengps-official/Boards)
 - [SK21 Rate Control Repository](https://github.com/agopengps-official/Rate_Control)
 
+## MQTT Section Control
+
+AgOpenGPS includes a lightweight MQTT client implementing the **MQTT Section Control Rule**. The client subscribes to
+`agopen/sectioncontrol/commands` and `agopen/system/commands` to receive section commands and shutdown requests.
+Status and acknowledgements are published every 30 seconds on `agopen/sectioncontrol/status` using JSON payloads.
+Refer to `MqttSectionControlClient` for integration details and examples.
+
 ## License
 
 If you distribute copies of such a program, whether

--- a/SourceCode/AgOpenGPS.Core/AgOpenGPS.Core.csproj
+++ b/SourceCode/AgOpenGPS.Core/AgOpenGPS.Core.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="NetTopologySuite.IO" Version="1.14.0.1" />
     <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="4.0.0" />
     <PackageReference Include="OpenTK" Version="3.3.3" />
+    <PackageReference Include="MQTTnet" Version="4.1.0" />
     <PackageReference Include="System.Text.Json" Version="9.0.4" />
     <ProjectReference Include="..\AgLibrary\AgLibrary.csproj" />
   </ItemGroup>

--- a/SourceCode/AgOpenGPS.Core/Communication/MqttSectionControlClient.cs
+++ b/SourceCode/AgOpenGPS.Core/Communication/MqttSectionControlClient.cs
@@ -1,0 +1,151 @@
+using MQTTnet;
+using MQTTnet.Client;
+using MQTTnet.Client.Options;
+using System;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AgOpenGPS.Core.Communication
+{
+    /// <summary>
+    /// Implements the MQTT Section Control Rule for AgOpenGPS.
+    /// Responsible for subscribing to section control commands and
+    /// publishing status, acknowledgements and errors.
+    /// </summary>
+    public class MqttSectionControlClient : IDisposable
+    {
+        private readonly IMqttClient _client;
+        private readonly IMqttClientOptions _options;
+        private readonly Timer _heartbeatTimer;
+
+        public event Action<int, bool>? SectionCommandReceived;
+        public event Action? ShutdownRequested;
+
+        public MqttSectionControlClient(string host, int port = 1883)
+        {
+            var factory = new MqttFactory();
+            _client = factory.CreateMqttClient();
+            _options = new MqttClientOptionsBuilder()
+                .WithTcpServer(host, port)
+                .Build();
+            _heartbeatTimer = new Timer(async _ => await PublishStatusAsync(), null, Timeout.Infinite, Timeout.Infinite);
+            _client.ApplicationMessageReceivedAsync += HandleMessageAsync;
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken = default)
+        {
+            await _client.ConnectAsync(_options, cancellationToken);
+            await _client.SubscribeAsync("agopen/sectioncontrol/commands", cancellationToken);
+            await _client.SubscribeAsync("agopen/system/commands", cancellationToken);
+            _heartbeatTimer.Change(TimeSpan.Zero, TimeSpan.FromSeconds(30));
+        }
+
+        private async Task HandleMessageAsync(MqttApplicationMessageReceivedEventArgs arg)
+        {
+            var payload = Encoding.UTF8.GetString(arg.ApplicationMessage.Payload ?? Array.Empty<byte>());
+            try
+            {
+                using var doc = JsonDocument.Parse(payload);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("command", out var cmdProp))
+                {
+                    var command = cmdProp.GetString();
+                    switch (command)
+                    {
+                        case "set_section":
+                            int section = root.GetProperty("section").GetInt32();
+                            string state = root.GetProperty("state").GetString() ?? "off";
+                            SectionCommandReceived?.Invoke(section, state.Equals("on", StringComparison.OrdinalIgnoreCase));
+                            await PublishAckAsync(section, state);
+                            break;
+                        case "shutdown":
+                            ShutdownRequested?.Invoke();
+                            await PublishAckAsync("shutdown");
+                            break;
+                        default:
+                            await PublishErrorAsync("unknown_command", command);
+                            break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                await PublishErrorAsync("invalid_payload", ex.Message);
+            }
+        }
+
+        public async Task PublishStatusAsync()
+        {
+            var payload = JsonSerializer.Serialize(new
+            {
+                status = "online",
+                program = "AgOpenGPS",
+                timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+            });
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("agopen/sectioncontrol/status")
+                .WithPayload(payload)
+                .WithAtLeastOnceQoS()
+                .Build();
+            if (_client.IsConnected)
+            {
+                await _client.PublishAsync(message);
+            }
+        }
+
+        private async Task PublishAckAsync(int section, string state)
+        {
+            var payload = JsonSerializer.Serialize(new
+            {
+                ack = "set_section",
+                section,
+                state
+            });
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("agopen/sectioncontrol/status")
+                .WithPayload(payload)
+                .WithAtLeastOnceQoS()
+                .Build();
+            if (_client.IsConnected)
+            {
+                await _client.PublishAsync(message);
+            }
+        }
+
+        private async Task PublishAckAsync(string command)
+        {
+            var payload = JsonSerializer.Serialize(new { ack = command });
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("agopen/sectioncontrol/status")
+                .WithPayload(payload)
+                .WithAtLeastOnceQoS()
+                .Build();
+            if (_client.IsConnected)
+            {
+                await _client.PublishAsync(message);
+            }
+        }
+
+        private async Task PublishErrorAsync(string error, string? detail = null)
+        {
+            var payload = JsonSerializer.Serialize(new { error, detail });
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("agopen/sectioncontrol/status")
+                .WithPayload(payload)
+                .WithAtLeastOnceQoS()
+                .Build();
+            if (_client.IsConnected)
+            {
+                await _client.PublishAsync(message);
+            }
+        }
+
+        public void Dispose()
+        {
+            _heartbeatTimer.Dispose();
+            _client?.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- integrate MQTTnet into AgOpenGPS.Core
- implement `MqttSectionControlClient` to handle MQTT Section Control Rule
- document MQTT feature in README

## Testing
- `dotnet test SourceCode/AgOpenGPS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686092122fc48321aaa72b3847d3044a